### PR TITLE
Place FAQ in summary section

### DIFF
--- a/assets/public.css
+++ b/assets/public.css
@@ -9472,6 +9472,7 @@ application-header .divider .wrapper .detail {
 .summary-flex {
   display: flex;
   width: 100%;
+  align-items: flex-start;
   gap: 1rem;
   padding: 0 1rem;
   box-sizing: border-box;
@@ -9484,6 +9485,10 @@ application-header .divider .wrapper .detail {
 .summary-flex .company-summary {
   margin: 0 auto;
   flex: 0 0 35%;
+}
+
+.summary-flex .faq {
+  margin-top: 1rem;
 }
 
 @media (max-width: 767px) {

--- a/index.html
+++ b/index.html
@@ -346,6 +346,63 @@
               </ul>
             </div>
           </div>
+          <div class="faq">
+            <details class="about-review">
+              <summary>Iedereen kan een review schrijven – onder voorwaarden</summary>
+              <div class="about-review-description">
+                <p>Een review mag worden geschreven door iedere klant met een aankoop- of gebruikservaring. Het is
+                  belangrijk dat de inhoud van de beoordeling gebaseerd is op een echte interactie met het bedrijf. Meer
+                  over wie een review mag schrijven en wanneer lees je hier.</p>
+              </div>
+            </details>
+            <details class="about-review">
+              <summary>Eerlijke feedback is waardevol</summary>
+              <div class="about-review-description">
+                <p>We moedigen klanten aan om hun ervaringen zo eerlijk, concreet en duidelijk mogelijk te beschrijven.
+                  Goede reviews helpen andere consumenten bij het maken van keuzes én geven bedrijven waardevolle
+                  inzichten om hun dienstverlening te verbeteren. Bekijk onze <a class="link"
+                    href="https://www.kiyoh.com/schrijf-je-kiyoh-review-in-minder-dan-60-seconden/" target="_blank">instructies</a>
+                  voor inspiratie.</p>
+              </div>
+            </details>
+            <details class="about-review">
+              <summary>We nemen misbruik serieus</summary>
+              <div class="about-review-description">
+                <p>Kiyoh zet zich actief in om misbruik en nepreviews tegen te gaan. Reviews die op eigen initiatief zijn
+                  geschreven worden direct online getoond en binnen 72 uur geverifieerd. Als er signalen zijn dat een
+                  beoordeling mogelijk onjuist of onrechtmatig is, nemen we maatregelen – waaronder aanvullende controles.
+                  We streven ernaar dat alle reviews bijdragen aan een betrouwbaar en representatief beeld. Lees meer over
+                  hoe wij nepreviews bestrijden.</p>
+              </div>
+            </details>
+            <details class="about-review">
+              <summary>Geen beloningen voor reviews</summary>
+              <div class="about-review-description">
+                <p>Verkopers mogen klanten geen financiële prikkels aanbieden in ruil voor beoordelingen. Dit betekent dat
+                  het aanbieden van gratis producten, cadeaubonnen, kortingen op toekomstige aankopen of andere vormen van
+                  beloning met geldwaarde niet is toegestaan – ongeacht of de review positief, negatief of neutraal is.
+                  Wanneer Kiyoh vaststelt dat een verkoper dergelijke incentives heeft aangeboden, worden de betreffende
+                  reviews uit de reviewfeed verwijderd.</p>
+              </div>
+            </details>
+            <details class="about-review">
+              <summary>Recente meningen bovenaan</summary>
+              <div class="about-review-description">
+                <p>Om gebruikers een actueel beeld te geven, tonen we standaard de meest recente reviews bovenaan. Zo kun je
+                  in één oogopslag zien hoe het bedrijf de laatste tijd heeft gepresteerd. Wil je meer weten over hoe deze
+                  reviewpagina tot stand komt? Lees dan hier meer.</p>
+              </div>
+            </details>
+            <details class="about-review">
+              <summary>Onafhankelijk en neutraal</summary>
+              <div class="about-review-description">
+                <p>Kiyoh is een onafhankelijk platform en erkend Google reviewpartner. Of een review nu lovend is of juist
+                  kritisch – iedere stem telt. Alleen zo ontstaat er een eerlijk en genuanceerd beeld waar zowel bedrijven
+                  als consumenten iets aan hebben. Wil je meer weten? Bekijk ons privacybeleid en ontdek hoe we omgaan met
+                  gegevens en reviews.</p>
+              </div>
+            </details>
+          </div>
         </div>
       </div>
     </div>
@@ -2026,61 +2083,6 @@
               beoordelingen.
             </p>
           </div>
-          <details class="about-review">
-            <summary>Iedereen kan een review schrijven – onder voorwaarden</summary>
-            <div class="about-review-description">
-              <p>Een review mag worden geschreven door iedere klant met een aankoop- of gebruikservaring. Het is
-                belangrijk dat de inhoud van de beoordeling gebaseerd is op een echte interactie met het bedrijf. Meer
-                over wie een review mag schrijven en wanneer lees je hier.</p>
-            </div>
-          </details>
-          <details class="about-review">
-            <summary>Eerlijke feedback is waardevol</summary>
-            <div class="about-review-description">
-              <p>We moedigen klanten aan om hun ervaringen zo eerlijk, concreet en duidelijk mogelijk te beschrijven.
-                Goede reviews helpen andere consumenten bij het maken van keuzes én geven bedrijven waardevolle
-                inzichten om hun dienstverlening te verbeteren. Bekijk onze <a class="link"
-                  href="https://www.kiyoh.com/schrijf-je-kiyoh-review-in-minder-dan-60-seconden/" target="_blank">instructies</a>
-                voor inspiratie.</p>
-            </div>
-          </details>
-          <details class="about-review">
-            <summary>We nemen misbruik serieus</summary>
-            <div class="about-review-description">
-              <p>Kiyoh zet zich actief in om misbruik en nepreviews tegen te gaan. Reviews die op eigen initiatief zijn
-                geschreven worden direct online getoond en binnen 72 uur geverifieerd. Als er signalen zijn dat een
-                beoordeling mogelijk onjuist of onrechtmatig is, nemen we maatregelen – waaronder aanvullende controles.
-                We streven ernaar dat alle reviews bijdragen aan een betrouwbaar en representatief beeld. Lees meer over
-                hoe wij nepreviews bestrijden.</p>
-            </div>
-          </details>
-          <details class="about-review">
-            <summary>Geen beloningen voor reviews</summary>
-            <div class="about-review-description">
-              <p>Verkopers mogen klanten geen financiële prikkels aanbieden in ruil voor beoordelingen. Dit betekent dat
-                het aanbieden van gratis producten, cadeaubonnen, kortingen op toekomstige aankopen of andere vormen van
-                beloning met geldwaarde niet is toegestaan – ongeacht of de review positief, negatief of neutraal is.
-                Wanneer Kiyoh vaststelt dat een verkoper dergelijke incentives heeft aangeboden, worden de betreffende
-                reviews uit de reviewfeed verwijderd.</p>
-            </div>
-          </details>
-          <details class="about-review">
-            <summary>Recente meningen bovenaan</summary>
-            <div class="about-review-description">
-              <p>Om gebruikers een actueel beeld te geven, tonen we standaard de meest recente reviews bovenaan. Zo kun je
-                in één oogopslag zien hoe het bedrijf de laatste tijd heeft gepresteerd. Wil je meer weten over hoe deze
-                reviewpagina tot stand komt? Lees dan hier meer.</p>
-            </div>
-          </details>
-          <details class="about-review">
-            <summary>Onafhankelijk en neutraal</summary>
-            <div class="about-review-description">
-              <p>Kiyoh is een onafhankelijk platform en erkend Google reviewpartner. Of een review nu lovend is of juist
-                kritisch – iedere stem telt. Alleen zo ontstaat er een eerlijk en genuanceerd beeld waar zowel bedrijven
-                als consumenten iets aan hebben. Wil je meer weten? Bekijk ons privacybeleid en ontdek hoe we omgaan met
-                gegevens en reviews.</p>
-            </div>
-          </details>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- embed FAQ details inside `.summary-flex`'s company summary section
- remove duplicate FAQ at the end of the page
- tweak `summary-flex` layout and add basic `.faq` styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684895b867e483248dce00292efe0a05