### PR TITLE
Fix font-family rule in public CSS

### DIFF
--- a/assets/public.css
+++ b/assets/public.css
@@ -461,7 +461,7 @@ body,
 p {
   font-size: 1rem;
   font-weight: 300;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif
+  font-family: Gotham, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
 body {


### PR DESCRIPTION
## Summary
- close body paragraph rule in CSS

## Testing
- `python3 - <<'PY'
text=open('assets/public.css').read()
count=0
for line in text.splitlines():
    count += line.count('{') - line.count('}')
print(count)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6850230b3e78832483a483466dd176f1