### PR TITLE
Add font-inheritance stylesheet

### DIFF
--- a/assets/public-2.css
+++ b/assets/public-2.css
@@ -1,0 +1,23 @@
+@import url('public.css');
+
+html, body {
+  font-family: Gotham, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 300;
+  font-style: normal;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+/* Inherit typography for common components */
+.alert,
+.form-control,
+.dropdown-menu,
+.btn,
+.tooltip,
+.popover,
+input,
+textarea,
+select {
+  font: inherit;
+  line-height: inherit;
+}


### PR DESCRIPTION
## Summary
- add a `public-2.css` stylesheet to ensure fonts inherit Gotham-based default styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685197df684c83249a21d18d6680e69c