### PR TITLE
Apply Gotham defaults across stylesheet

### DIFF
--- a/assets/public.css
+++ b/assets/public.css
@@ -3445,7 +3445,7 @@ review-filters .filters {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -55%);
+  transform: translate(-50%, -50%);
   z-index: 1;
   font-family: var(--font);
   font-weight: 700;
@@ -3477,7 +3477,7 @@ body.dark-mode .average-rating-number-container {
   top: 50%;
   left: 0;
   width: 100%;
-  margin: -.55em 0 0 -.04em;
+  transform: translateY(-50%);
   letter-spacing: -.05em;
   text-align: center;
   line-height: 1;
@@ -9640,6 +9640,7 @@ body.dark-mode .summary-flex {
   line-height: 1;
   display: inline-block;
   margin-left: 0.5rem;
+  font-family: FontAwesome;
 }
 .faq details[open] summary .toggle {
   transform: rotate(180deg);

--- a/assets/public.css
+++ b/assets/public.css
@@ -3427,10 +3427,10 @@ review-filters .filters {
 
 .rating-number {
   overflow: hidden;
-  font-size: 2.5em;
+  font-size: 2em;
   position: relative;
   line-height: 0;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .rating-number svg {
@@ -3445,11 +3445,12 @@ review-filters .filters {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -55%);
   z-index: 1;
   font-family: var(--font);
   font-weight: 700;
   line-height: 1;
+  white-space: nowrap;
 }
 
 .average-rating-number-container {
@@ -9819,7 +9820,7 @@ body.dark-mode .summary-flex {
 }
 
 .review > .review-content > .left {
-  margin-right: 2em;
+  margin-right: 2.5em;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -9838,7 +9839,10 @@ body.dark-mode .summary-flex {
   flex: 0 0 auto;
 }
 
-.review > .review-content > .left > .overall-rating-stars { display: none; }
+.review > .review-content > .left > .overall-rating-stars {
+  display: none;
+  margin-top: 0.5rem;
+}
 
 @media only screen and (max-width:1023px) {
   .review > .review-content {
@@ -10139,7 +10143,7 @@ header.public-header .header-links {
     "num stars"
     "text text"
     "extra extra";
-  gap: 0.5rem 1rem;
+  gap: 0.5rem 2rem;
 }
 
 .review > .review-content > .left,
@@ -10600,6 +10604,8 @@ review-filters .js-clear-button:hover {
   display: flex;
   gap: 1rem;
   justify-content: center;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .menu-actions button {

--- a/assets/public.css
+++ b/assets/public.css
@@ -3429,13 +3429,14 @@ review-filters .filters {
 .rating-number span {
   color: #fff;
   position: absolute;
-  top: 44%;
+  top: 50%;
   left: 0;
   width: 100%;
   text-align: center;
-  margin-top: -.5em;
+  transform: translateY(-50%);
   z-index: 1;
   font-family: var(--font);
+  line-height: 1;
 }
 
 .average-rating-number-container {
@@ -3462,9 +3463,10 @@ body.dark-mode .average-rating-number-container {
   top: 50%;
   left: 0;
   width: 100%;
-  margin: -.55em 0 0 -.04em;
+  transform: translateY(-50%);
   letter-spacing: -.05em;
-  text-align: center
+  text-align: center;
+  line-height: 1;
 }
 
 /* Ensure all numeric ratings use Gotham */
@@ -6223,9 +6225,10 @@ html.widget-document body.kv-widget-body .default-widget-rating-number>.rating {
   top: 50%;
   left: 0;
   width: 100%;
-  margin: -.55em 0 0 -.04em;
+  transform: translateY(-50%);
   letter-spacing: -.05em;
-  text-align: center
+  text-align: center;
+  line-height: 1;
 }
 
 html.widget-document body.kv-widget-body .default-widget-rating-number:before {
@@ -10510,6 +10513,17 @@ header.public-header .header-rating {
 }
 .public-filter .js-filter-button {
   display: none;
+}
+.public-filter .js-clear-button,
+.public-review-filter .js-clear-button,
+review-filters .js-clear-button {
+  background: #ed8c00;
+  color: #fff;
+}
+.public-filter .js-clear-button:hover,
+.public-review-filter .js-clear-button:hover,
+review-filters .js-clear-button:hover {
+  background: #c97700;
 }
 
 .menu-actions {

--- a/assets/public.css
+++ b/assets/public.css
@@ -3420,7 +3420,7 @@ review-filters .filters {
   font-size: 2.5em;
   position: relative;
   line-height: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 }
 
 .rating-number svg {
@@ -3468,7 +3468,7 @@ body.dark-mode .average-rating-number-container {
   top: 50%;
   left: 0;
   width: 100%;
-  transform: translateY(-50%);
+  margin: -.55em 0 0 -.04em;
   letter-spacing: -.05em;
   text-align: center;
   line-height: 1;
@@ -4180,7 +4180,7 @@ table th.full {
 }
 
 .review-summary .overall-rating .rating-stars {
-  margin: 2% 0
+  margin: 1rem 0;
 }
 
 .review-summary .overall-rating .rating-stars [class^=icon-star] {
@@ -9626,6 +9626,9 @@ body.dark-mode .summary-flex {
   display: inline-block;
   margin-left: 0.5rem;
 }
+.faq details[open] summary .toggle {
+  transform: rotate(180deg);
+}
 
 .faq .about-review-description {
   padding: 0 1.2rem 1rem;
@@ -9666,10 +9669,10 @@ body.dark-mode .summary-flex {
   width: 100%;
   height: 100%;
   border: 0;
-  pointer-events: none;
 }
 
 .company-summary .map-overlay {
+  display: none;
   position: absolute;
   top: 0;
   left: 0;
@@ -9677,7 +9680,6 @@ body.dark-mode .summary-flex {
   bottom: 0;
   background: rgba(255, 255, 255, 0.6);
   backdrop-filter: blur(2px);
-  display: flex;
   align-items: center;
   justify-content: center;
   font-size: 2rem;
@@ -9690,6 +9692,15 @@ body.dark-mode .summary-flex {
 
 .company-summary .osm-link {
   display: none;
+}
+
+@media (max-width: 767px) {
+  .company-summary .map-square iframe {
+    pointer-events: none;
+  }
+  .company-summary .map-overlay {
+    display: flex;
+  }
 }
 
 @media (max-width: 600px) {
@@ -9738,7 +9749,7 @@ body.dark-mode .summary-flex {
 }
 
 .company-summary .contact-buttons button .fa {
-  font-size: 1.2em;
+  font-size: 1.5em;
 }
 
 .company-summary .opening-hours ul {
@@ -10129,6 +10140,7 @@ header.public-header .header-links {
 .review > .review-content > .right > .overall-rating-stars {
   grid-area: stars;
   align-self: center;
+  margin-top: 0.5rem;
 }
 
 .review > .review-content > .right > .rating-description {
@@ -10339,6 +10351,10 @@ header.public-header .header-links {
   justify-content: center;
   padding: 0.9rem 0;
   font-size: 1.1rem;
+}
+.company-summary .contact-actions .secondary-buttons a .fa,
+.company-summary .contact-actions .website-btn .fa {
+  font-size: 1.5em;
 }
 
 @media (max-width: 767px) {

--- a/assets/public.css
+++ b/assets/public.css
@@ -108,7 +108,7 @@ img {
 .application-header,
 application-header {
   font-weight: 300;
-  font-family: Gotham, Arial;
+  font-family: var(--font);
   display: block;
   background: #fff;
   color: #464343;
@@ -266,13 +266,13 @@ application-header .page-heading h2:empty:before {
 .application-header .page-heading h1,
 application-header .page-heading h1 {
   font-weight: 500;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 .application-header .page-heading h2,
 application-header .page-heading h2 {
   font-weight: 300;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 .application-header .page-heading .logo:not(:last-child),
@@ -299,7 +299,7 @@ application-header .page-heading .help-link {
   font-size: .875rem;
   line-height: 1.125rem;
   font-weight: 300;
-  font-family: Gotham, Arial;
+  font-family: var(--font);
   color: #00b7ed;
   position: absolute;
   top: -1.8em;
@@ -348,7 +348,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 h1>.help.help:after,
@@ -458,21 +458,22 @@ html {
 }
 
 :root {
-  --font: Gotham, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font: Gotham, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 body,
 p {
-  font-size: 1rem;
+  font-size: 15px;
   font-weight: 300;
   font-family: var(--font);
+  font-style: normal;
+  line-height: 1.6;
 }
 
 body {
   color: #464343;
   background: #fff;
   min-height: 100%;
-  line-height: 1;
   word-wrap: break-word;
   word-break: break-word
 }
@@ -613,7 +614,7 @@ section {
 .small {
   line-height: 1.125rem;
   font-weight: 300;
-  font-family: Gotham, Arial;
+  font-family: var(--font);
   color: #716c6c
 }
 
@@ -627,7 +628,7 @@ display {
   font-size: 2.5rem;
   line-height: 2.625rem;
   font-weight: 500;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 intro,
@@ -635,7 +636,7 @@ quote {
   display: block;
   font-size: 1.125rem;
   font-weight: 300;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 intro {
@@ -661,7 +662,7 @@ quote.quaternary {
 
 .handwritten {
   font-weight: 400;
-  font-family: Angelina, Arial;
+  font-family: var(--font);
   font-size: 1.5rem;
   line-height: 2rem
 }
@@ -670,7 +671,7 @@ quote.quaternary {
 b,
 strong {
   font-weight: 500;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 .line-height {
@@ -1434,7 +1435,7 @@ button:not(.no-style) {
 
 .as-button:not(.no-style):not([class^=icon-]),
 button:not(.no-style):not([class^=icon-]) {
-  font-family: "Fonecta Bold", Gotham, Arial
+  font-family: var(--font)
 }
 
 .as-button:not(.no-style).shrink,
@@ -2157,7 +2158,7 @@ language-switcher .options.show {
 .language-switcher .options li.active,
 language-switcher .options li.active {
   font-weight: 700;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 .public-page.location-group .language-switcher .options,
@@ -2738,7 +2739,7 @@ product-cluster .cluster-container .product-table list .table-holder td.product-
 .product-cluster .cluster-container .product-table list .selected,
 product-cluster .cluster-container .product-table list .selected {
   font-weight: 700;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 @media only screen and (max-width:767px) {
@@ -3434,7 +3435,7 @@ review-filters .filters {
   text-align: center;
   margin-top: -.5em;
   z-index: 1;
-  font-family: Gotham, Arial, sans-serif;
+  font-family: var(--font);
 }
 
 .average-rating-number-container {
@@ -3456,7 +3457,7 @@ body.dark-mode .average-rating-number-container {
   display: block;
   position: absolute;
   font-weight: 500;
-  font-family: Gotham, Arial;
+  font-family: var(--font);
   font-size: 4rem;
   top: 50%;
   left: 0;
@@ -3468,7 +3469,7 @@ body.dark-mode .average-rating-number-container {
 
 /* Ensure all numeric ratings use Gotham */
 .rating {
-  font-family: Gotham, Arial, sans-serif;
+  font-family: var(--font);
 }
 
 .footer-bottom-col,
@@ -3704,7 +3705,7 @@ review-filters .ui-select {
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
   width: 6.6em;
-  font-family: Gotham, Arial, sans-serif;
+  font-family: var(--font);
 }
 
 @media only screen and (min-width:1024px) {
@@ -3885,7 +3886,7 @@ table th.full {
 
 .review .meta-data .created-date {
   font-weight: 700;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 .review .meta-data .more-meta-data table {
@@ -4172,7 +4173,7 @@ table th.full {
 .review-summary .overall-rating .summary {
   font-size: .875rem;
   font-weight: 300;
-  font-family: Gotham, Arial;
+  font-family: var(--font);
   color: #716c6c;
   line-height: 1.3
 }
@@ -4225,7 +4226,7 @@ table th.full {
 .review-summary .ratings-per-division .heading {
   font-size: 1.125em;
   font-weight: 700;
-  font-family: Gotham, Arial;
+  font-family: var(--font);
   margin-bottom: 1em
 }
 
@@ -4287,7 +4288,7 @@ table th {
 .public-page.confirmation .verify-email,
 table.lined-table thead {
   font-weight: 500;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 table td.fit,
@@ -4490,12 +4491,12 @@ table.lined-table checkbox.slider {
 
 .public-login-page .login-panel .heading span {
   font-weight: 700;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 .public-login-page .login-panel>.content {
   font-weight: 300;
-  font-family: Gotham, Arial;
+  font-family: var(--font);
   padding: 1.5em 1em
 }
 
@@ -5868,7 +5869,7 @@ table.lined-table checkbox.slider {
 }
 
 .signup-page * {
-  font-family: Metropolis
+  font-family: var(--font)
 }
 
 .signup-page .title {
@@ -6152,7 +6153,7 @@ html.widget-document body.kv-widget-body {
   font-size: 1em;
   overflow: hidden;
   font-weight: 300;
-  font-family: Gotham, Arial
+  font-family: var(--font)
 }
 
 html.widget-document body.kv-widget-body.theme-white {
@@ -6216,7 +6217,7 @@ html.widget-document body.kv-widget-body .default-widget-rating-number>.rating {
   display: block;
   position: absolute;
   font-weight: 500;
-  font-family: Gotham, Arial;
+  font-family: var(--font);
   font-size: 3.2em;
   top: 50%;
   left: 0;
@@ -6246,7 +6247,7 @@ html.widget-document body.kv-widget-body .portal-wrapper .powered-by {
 html.widget-document body.kv-widget-body .portal-wrapper .name {
   font-size: 1.8em;
   display: inline;
-  font-family: "Fonecta Book", Gotham, Arial
+  font-family: var(--font)
 }
 
 html.widget-document body.kv-widget-body .portal-wrapper .name span {
@@ -6256,8 +6257,7 @@ html.widget-document body.kv-widget-body .portal-wrapper .name span {
 
 html.widget-document body.kv-widget-body .portal-wrapper .name span:last-child {
   font-weight: 500;
-  font-family: Gotham, Arial;
-  font-family: "Fonecta Bold", Gotham, Arial
+  font-family: var(--font);
 }
 
 html.widget-document body.kv-widget-body .reviews {
@@ -6291,7 +6291,7 @@ html.widget-document body.kv-widget-body .reviews .review>* {
 
 html.widget-document body.kv-widget-body .reviews .review .oneliner {
   font-weight: 500;
-  font-family: Gotham, Arial;
+  font-family: var(--font);
   margin-bottom: .4em
 }
 

--- a/assets/public.css
+++ b/assets/public.css
@@ -9636,18 +9636,14 @@ body.dark-mode .summary-flex {
 .faq summary::-webkit-details-marker{display:none;}
 
 .faq summary .toggle {
+  font-family: FontAwesome;
   font-size: 1.3rem;
   line-height: 1;
   display: inline-block;
   margin-left: 0.5rem;
-}
-.faq summary .toggle::before {
-  font-family: FontAwesome;
-  content: "\f078";
-  display: inline-block;
   transition: transform 0.2s;
 }
-.faq details[open] summary .toggle::before {
+.faq details[open] summary .toggle {
   transform: rotate(180deg);
 }
 

--- a/assets/public.css
+++ b/assets/public.css
@@ -3418,12 +3418,16 @@ review-filters .filters {
 .rating-number {
   overflow: hidden;
   font-size: 2.5em;
-  position: relative
+  position: relative;
+  line-height: 0;
+  margin-bottom: 0.5rem;
 }
 
 .rating-number svg {
   height: 2em;
-  width: 1.85em
+  width: 1.85em;
+  display: block;
+  margin: 0 auto;
 }
 
 .rating-number span {
@@ -9602,6 +9606,8 @@ body.dark-mode .summary-flex {
   color: #111;
   cursor: pointer;
 }
+.faq summary::marker,
+.faq summary::-webkit-details-marker{display:none;}
 
 .faq summary .toggle {
   font-size: 1.3rem;

--- a/assets/public.css
+++ b/assets/public.css
@@ -1872,7 +1872,7 @@ label.checkbox input:disabled+.selector {
     padding-bottom: 0.25em;
   }
   header.public-header .portal-logo img {
-    max-height: 3em;
+    max-height: 2.5em;
   }
 }
 
@@ -3445,7 +3445,7 @@ review-filters .filters {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -55%);
   z-index: 1;
   font-family: var(--font);
   font-weight: 700;
@@ -9640,9 +9640,14 @@ body.dark-mode .summary-flex {
   line-height: 1;
   display: inline-block;
   margin-left: 0.5rem;
-  font-family: FontAwesome;
 }
-.faq details[open] summary .toggle {
+.faq summary .toggle::before {
+  font-family: FontAwesome;
+  content: "\f078";
+  display: inline-block;
+  transition: transform 0.2s;
+}
+.faq details[open] summary .toggle::before {
   transform: rotate(180deg);
 }
 
@@ -10535,6 +10540,7 @@ header.public-header .header-rating {
   }
   header.public-header .portal-logo img {
     max-width: 7em;
+    max-height: 2.5em;
   }
 }
 

--- a/assets/public.css
+++ b/assets/public.css
@@ -3420,7 +3420,7 @@ review-filters .filters {
   font-size: 2.5em;
   position: relative;
   line-height: 0;
-  margin-bottom: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 .rating-number svg {
@@ -3433,13 +3433,14 @@ review-filters .filters {
 .rating-number span {
   color: #fff;
   position: absolute;
-  top: 50%;
+  top: 45%;
   left: 0;
   width: 100%;
   text-align: center;
   transform: translateY(-50%);
   z-index: 1;
   font-family: var(--font);
+  font-weight: 700;
   line-height: 1;
 }
 
@@ -3471,6 +3472,16 @@ body.dark-mode .average-rating-number-container {
   letter-spacing: -.05em;
   text-align: center;
   line-height: 1;
+}
+
+@media (max-width: 767px) {
+  .average-rating-number-container {
+    width: 6.5rem;
+    height: 6.5rem;
+  }
+  .average-rating-number-container > .rating {
+    font-size: 2rem;
+  }
 }
 
 /* Ensure all numeric ratings use Gotham */
@@ -9612,6 +9623,8 @@ body.dark-mode .summary-flex {
 .faq summary .toggle {
   font-size: 1.3rem;
   line-height: 1;
+  display: inline-block;
+  margin-left: 0.5rem;
 }
 
 .faq .about-review-description {
@@ -9646,12 +9659,33 @@ body.dark-mode .summary-flex {
   border-radius: 0.75rem;
   overflow: hidden;
   margin: 1.5rem auto 1em;
+  position: relative;
 }
 
 .company-summary .map-square iframe {
   width: 100%;
   height: 100%;
   border: 0;
+  pointer-events: none;
+}
+
+.company-summary .map-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  color: #333;
+}
+
+.company-summary .map-overlay.hidden {
+  display: none;
 }
 
 .company-summary .osm-link {

--- a/assets/public.css
+++ b/assets/public.css
@@ -3470,6 +3470,7 @@ body.dark-mode .average-rating-number-container {
 /* Ensure all numeric ratings use Gotham */
 .rating {
   font-family: var(--font);
+  line-height: 1;
 }
 
 .footer-bottom-col,

--- a/assets/public.css
+++ b/assets/public.css
@@ -1866,6 +1866,16 @@ label.checkbox input:disabled+.selector {
   -webkit-backdrop-filter: blur(8px);
 }
 
+@media (max-width: 767px) {
+  .public-page:not(.location-group) header.public-header {
+    padding-top: 0.5em;
+    padding-bottom: 0.25em;
+  }
+  header.public-header .portal-logo img {
+    max-height: 3em;
+  }
+}
+
 .public-page:not(.location-group) header.public-header>.content {
   border-bottom: none;
   padding-bottom: .5em
@@ -3433,11 +3443,9 @@ review-filters .filters {
 .rating-number span {
   color: #fff;
   position: absolute;
-  top: 45%;
-  left: 0;
-  width: 100%;
-  text-align: center;
-  transform: translateY(-50%);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: 1;
   font-family: var(--font);
   font-weight: 700;
@@ -3754,8 +3762,8 @@ table th.full {
 }
 
 .review {
-  margin: 1.25em 0;
-  padding: 1em;
+  margin: 1em 0;
+  padding: 0.75em;
   border-radius: 15px;
   background: rgba(255, 255, 255, 0.6);
   border: 1px solid rgba(200, 200, 200, 0.3);
@@ -3918,6 +3926,12 @@ table th.full {
 
 .review .meta-data .more-meta-data table td:first-child {
   padding-right: .25em
+}
+
+@media (max-width: 600px) {
+  .review .meta-data .more-meta-data table {
+    margin-left: 1rem;
+  }
 }
 
 @media (max-width:600px) {
@@ -4165,8 +4179,8 @@ table th.full {
   -ms-flex-align: center;
   align-items: center;
   text-align: center;
-  margin-bottom: 1em;
-  padding: 1em;
+  margin-bottom: 0.5em;
+  padding: 0.75em;
   -webkit-box-flex: 0;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto
@@ -4224,7 +4238,7 @@ table th.full {
   -webkit-box-flex: 1;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
-  padding: 1em
+  padding: 0.75em 1em
 }
 
 .public-login-page .page-container,
@@ -5813,8 +5827,8 @@ table.lined-table checkbox.slider {
 }
 
 .review-list .review {
-  margin: 2em 0;
-  padding: 1.5em;
+  margin: 1em 0;
+  padding: 0.75em;
   border-radius: 15px;
   background: rgba(255, 255, 255, 0.6);
   border: 1px solid rgba(200, 200, 200, 0.3);

--- a/assets/review-interactions.js
+++ b/assets/review-interactions.js
@@ -95,5 +95,28 @@ document.addEventListener('DOMContentLoaded', function () {
       link.style.display = 'none';
     }
   });
+
+  var mapSquare = document.querySelector('.map-square');
+  if (mapSquare) {
+    var iframe = mapSquare.querySelector('iframe');
+    var overlay = mapSquare.querySelector('.map-overlay');
+    if (iframe && overlay) {
+      var hold;
+      function activate() {
+        overlay.classList.add('hidden');
+        iframe.style.pointerEvents = 'auto';
+      }
+      function startHold() {
+        hold = setTimeout(activate, 600);
+      }
+      function cancelHold() {
+        clearTimeout(hold);
+      }
+      overlay.addEventListener('touchstart', startHold);
+      overlay.addEventListener('mousedown', startHold);
+      overlay.addEventListener('touchend', cancelHold);
+      overlay.addEventListener('mouseup', cancelHold);
+    }
+  }
 });
 

--- a/assets/review-interactions.js
+++ b/assets/review-interactions.js
@@ -97,7 +97,7 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   var mapSquare = document.querySelector('.map-square');
-  if (mapSquare) {
+  if (mapSquare && window.matchMedia('(max-width: 767px)').matches) {
     var iframe = mapSquare.querySelector('iframe');
     var overlay = mapSquare.querySelector('.map-overlay');
     if (iframe && overlay) {

--- a/index.html
+++ b/index.html
@@ -434,9 +434,6 @@
       <div class="company-info frosted-card">
         <h3>Over Kiyoh</h3>
         <p class="company-intro">Kiyoh helpt bedrijven transparant klantbeoordelingen verzamelen.</p>
-        <p class="user-defined-content js-email-click-count">
-          <a href="mailto:info@kiyoh">info@kiyoh</a>
-        </p>
         <div class="faq">
       <details class="about-review">
         <summary>Iedereen kan een review schrijven – onder voorwaarden <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>

--- a/index.html
+++ b/index.html
@@ -436,7 +436,7 @@
         <p class="company-intro">Kiyoh helpt bedrijven transparant klantbeoordelingen verzamelen.</p>
         <div class="faq">
       <details class="about-review">
-        <summary>Iedereen kan een review schrijven – onder voorwaarden <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
+        <summary>Iedereen kan een review schrijven – onder voorwaarden <span class="toggle"></span></summary>
         <div class="about-review-description">
           <p>Een review mag worden geschreven door iedere klant met een aankoop- of gebruikservaring. Het is
             belangrijk dat de inhoud van de beoordeling gebaseerd is op een echte interactie met het bedrijf. Meer
@@ -444,7 +444,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Eerlijke feedback is waardevol <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
+        <summary>Eerlijke feedback is waardevol <span class="toggle"></span></summary>
         <div class="about-review-description">
           <p>We moedigen klanten aan om hun ervaringen zo eerlijk, concreet en duidelijk mogelijk te beschrijven.
             Goede reviews helpen andere consumenten bij het maken van keuzes én geven bedrijven waardevolle
@@ -453,7 +453,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>We nemen misbruik serieus <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
+        <summary>We nemen misbruik serieus <span class="toggle"></span></summary>
         <div class="about-review-description">
           <p>Kiyoh zet zich actief in om misbruik en nepreviews tegen te gaan. Reviews die op eigen initiatief zijn
             geschreven worden direct online getoond en binnen 72 uur geverifieerd. Als er signalen zijn dat een
@@ -463,7 +463,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Geen beloningen voor reviews <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
+        <summary>Geen beloningen voor reviews <span class="toggle"></span></summary>
         <div class="about-review-description">
           <p>Verkopers mogen klanten geen financiële prikkels aanbieden in ruil voor beoordelingen. Dit betekent dat
             het aanbieden van gratis producten, cadeaubonnen, kortingen op toekomstige aankopen of andere vormen van
@@ -473,7 +473,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Recente meningen bovenaan <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
+        <summary>Recente meningen bovenaan <span class="toggle"></span></summary>
         <div class="about-review-description">
           <p>Om gebruikers een actueel beeld te geven, tonen we standaard de meest recente reviews bovenaan. Zo kun je
             in één oogopslag zien hoe het bedrijf de laatste tijd heeft gepresteerd. Wil je meer weten over hoe deze
@@ -481,7 +481,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Onafhankelijk en neutraal <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
+        <summary>Onafhankelijk en neutraal <span class="toggle"></span></summary>
         <div class="about-review-description">
           <p>Kiyoh is een onafhankelijk platform en erkend Google reviewpartner. Of een review nu lovend is of juist
             kritisch – iedere stem telt. Alleen zo ontstaat er een eerlijk en genuanceerd beeld waar zowel bedrijven
@@ -490,7 +490,7 @@
         </div>
         </details>
       <details class="about-review">
-        <summary>Bedrijfsinformatie Kiyoh <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
+        <summary>Bedrijfsinformatie Kiyoh <span class="toggle"></span></summary>
         <div class="about-review-description">
           <p>Bezoekadres<br />Dr. Hub van Doorneweg 169<br />5026 RC Tilburg<br />Kiyoh is Google Partner.<br />Gegevens<br />013 – 7009708<br />info@kiyoh<br />KVK nummer: 81275048<br />Openingstijden<br />Maandag t/m vrijdag<br />8.30 – 17.00 uur</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -314,6 +314,7 @@
               loading="lazy"
               referrerpolicy="no-referrer-when-downgrade">
             </iframe>
+            <div class="map-overlay"><span class="fa fa-hand-pointer-o"></span></div>
           </div>
           <small class="osm-link">
             <a href="https://www.openstreetmap.org/?mlat=51.5585&mlon=5.1155#map=16/51.5585/5.1155" target="_blank" rel="noopener">Bekijk op OpenStreetMap</a>

--- a/index.html
+++ b/index.html
@@ -436,7 +436,7 @@
         <p class="company-intro">Kiyoh helpt bedrijven transparant klantbeoordelingen verzamelen.</p>
         <div class="faq">
       <details class="about-review">
-        <summary>Iedereen kan een review schrijven – onder voorwaarden <span class="toggle"></span></summary>
+        <summary>Iedereen kan een review schrijven – onder voorwaarden <span class="toggle fa fa-chevron-down"></span></summary>
         <div class="about-review-description">
           <p>Een review mag worden geschreven door iedere klant met een aankoop- of gebruikservaring. Het is
             belangrijk dat de inhoud van de beoordeling gebaseerd is op een echte interactie met het bedrijf. Meer
@@ -444,7 +444,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Eerlijke feedback is waardevol <span class="toggle"></span></summary>
+        <summary>Eerlijke feedback is waardevol <span class="toggle fa fa-chevron-down"></span></summary>
         <div class="about-review-description">
           <p>We moedigen klanten aan om hun ervaringen zo eerlijk, concreet en duidelijk mogelijk te beschrijven.
             Goede reviews helpen andere consumenten bij het maken van keuzes én geven bedrijven waardevolle
@@ -453,7 +453,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>We nemen misbruik serieus <span class="toggle"></span></summary>
+        <summary>We nemen misbruik serieus <span class="toggle fa fa-chevron-down"></span></summary>
         <div class="about-review-description">
           <p>Kiyoh zet zich actief in om misbruik en nepreviews tegen te gaan. Reviews die op eigen initiatief zijn
             geschreven worden direct online getoond en binnen 72 uur geverifieerd. Als er signalen zijn dat een
@@ -463,7 +463,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Geen beloningen voor reviews <span class="toggle"></span></summary>
+        <summary>Geen beloningen voor reviews <span class="toggle fa fa-chevron-down"></span></summary>
         <div class="about-review-description">
           <p>Verkopers mogen klanten geen financiële prikkels aanbieden in ruil voor beoordelingen. Dit betekent dat
             het aanbieden van gratis producten, cadeaubonnen, kortingen op toekomstige aankopen of andere vormen van
@@ -473,7 +473,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Recente meningen bovenaan <span class="toggle"></span></summary>
+        <summary>Recente meningen bovenaan <span class="toggle fa fa-chevron-down"></span></summary>
         <div class="about-review-description">
           <p>Om gebruikers een actueel beeld te geven, tonen we standaard de meest recente reviews bovenaan. Zo kun je
             in één oogopslag zien hoe het bedrijf de laatste tijd heeft gepresteerd. Wil je meer weten over hoe deze
@@ -481,7 +481,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Onafhankelijk en neutraal <span class="toggle"></span></summary>
+        <summary>Onafhankelijk en neutraal <span class="toggle fa fa-chevron-down"></span></summary>
         <div class="about-review-description">
           <p>Kiyoh is een onafhankelijk platform en erkend Google reviewpartner. Of een review nu lovend is of juist
             kritisch – iedere stem telt. Alleen zo ontstaat er een eerlijk en genuanceerd beeld waar zowel bedrijven
@@ -490,7 +490,7 @@
         </div>
         </details>
       <details class="about-review">
-        <summary>Bedrijfsinformatie Kiyoh <span class="toggle"></span></summary>
+        <summary>Bedrijfsinformatie Kiyoh <span class="toggle fa fa-chevron-down"></span></summary>
         <div class="about-review-description">
           <p>Bezoekadres<br />Dr. Hub van Doorneweg 169<br />5026 RC Tilburg<br />Kiyoh is Google Partner.<br />Gegevens<br />013 – 7009708<br />info@kiyoh<br />KVK nummer: 81275048<br />Openingstijden<br />Maandag t/m vrijdag<br />8.30 – 17.00 uur</p>
         </div>
@@ -581,8 +581,7 @@
                       </div>
                       <p>Beste Robin,
 
-                        Bedankt voor het schrijven van uw review. Wat jammer om te lezen dat uw ervaring met kiyoh niet
-                        aan uw verwachtingen heeft voldaan. Dat vinden we oprecht vervelend.
+                        Dat vinden we oprecht vervelend.
 
                         We hebben geprobeerd telefonisch contact met u op te nemen om uw situatie persoonlijk te
                         bespreken, maar helaas hebben we u nog niet kunnen bereiken.
@@ -1775,8 +1774,6 @@
                         <h3>Reactie van het bedrijf</h3>
                       </div>
                       <p>Beste Frederic,
-
-                        Dank voor uw bericht. Jammer om te horen dat uw ervaring niet positief is geweest.
 
                         Graag lichten we toe dat opzeggen bij ons heel eenvoudig kan via e-mail. De verlenging van het
                         abonnement gebeurt niet stilzwijgend, we vermelden dit duidelijk in de overeenkomst én op de

--- a/index.html
+++ b/index.html
@@ -434,18 +434,12 @@
       <div class="company-info frosted-card">
         <h3>Over Kiyoh</h3>
         <p class="company-intro">Kiyoh helpt bedrijven transparant klantbeoordelingen verzamelen.</p>
-        <p class="user-defined-content js-phone-number-click-count">
-          <a href="https://www.kiyoh/reviews/1044505/kiyoh_nl_klantbeoordelingen?from=widget&amp;lang=nl" target="_blank" tcxhref="0137009708" title="Call 013 700 9708 via 3CX">013 700 9708</a>
-        </p>
         <p class="user-defined-content js-email-click-count">
           <a href="mailto:info@kiyoh">info@kiyoh</a>
         </p>
-        <div class="company-link user-defined-content" style="font-size:16px;">
-          <a class="js-website-url-click-count" href="https://www.kiyoh/" target="_blank">www.kiyoh</a>
-        </div>
         <div class="faq">
       <details class="about-review">
-        <summary>Iedereen kan een review schrijven – onder voorwaarden <span class="toggle">&#x25BC;</span></summary>
+        <summary>Iedereen kan een review schrijven – onder voorwaarden <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
         <div class="about-review-description">
           <p>Een review mag worden geschreven door iedere klant met een aankoop- of gebruikservaring. Het is
             belangrijk dat de inhoud van de beoordeling gebaseerd is op een echte interactie met het bedrijf. Meer
@@ -453,7 +447,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Eerlijke feedback is waardevol <span class="toggle">&#x25BC;</span></summary>
+        <summary>Eerlijke feedback is waardevol <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
         <div class="about-review-description">
           <p>We moedigen klanten aan om hun ervaringen zo eerlijk, concreet en duidelijk mogelijk te beschrijven.
             Goede reviews helpen andere consumenten bij het maken van keuzes én geven bedrijven waardevolle
@@ -462,7 +456,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>We nemen misbruik serieus <span class="toggle">&#x25BC;</span></summary>
+        <summary>We nemen misbruik serieus <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
         <div class="about-review-description">
           <p>Kiyoh zet zich actief in om misbruik en nepreviews tegen te gaan. Reviews die op eigen initiatief zijn
             geschreven worden direct online getoond en binnen 72 uur geverifieerd. Als er signalen zijn dat een
@@ -472,7 +466,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Geen beloningen voor reviews <span class="toggle">&#x25BC;</span></summary>
+        <summary>Geen beloningen voor reviews <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
         <div class="about-review-description">
           <p>Verkopers mogen klanten geen financiële prikkels aanbieden in ruil voor beoordelingen. Dit betekent dat
             het aanbieden van gratis producten, cadeaubonnen, kortingen op toekomstige aankopen of andere vormen van
@@ -482,7 +476,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Recente meningen bovenaan <span class="toggle">&#x25BC;</span></summary>
+        <summary>Recente meningen bovenaan <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
         <div class="about-review-description">
           <p>Om gebruikers een actueel beeld te geven, tonen we standaard de meest recente reviews bovenaan. Zo kun je
             in één oogopslag zien hoe het bedrijf de laatste tijd heeft gepresteerd. Wil je meer weten over hoe deze
@@ -490,7 +484,7 @@
         </div>
       </details>
       <details class="about-review">
-        <summary>Onafhankelijk en neutraal <span class="toggle">&#x25BC;</span></summary>
+        <summary>Onafhankelijk en neutraal <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
         <div class="about-review-description">
           <p>Kiyoh is een onafhankelijk platform en erkend Google reviewpartner. Of een review nu lovend is of juist
             kritisch – iedere stem telt. Alleen zo ontstaat er een eerlijk en genuanceerd beeld waar zowel bedrijven
@@ -499,7 +493,7 @@
         </div>
         </details>
       <details class="about-review">
-        <summary>Bedrijfsinformatie Kiyoh <span class="toggle">&#x25BC;</span></summary>
+        <summary>Bedrijfsinformatie Kiyoh <span class="fa fa-chevron-down toggle" aria-hidden="true"></span></summary>
         <div class="about-review-description">
           <p>Bezoekadres<br />Dr. Hub van Doorneweg 169<br />5026 RC Tilburg<br />Kiyoh is Google Partner.<br />Gegevens<br />013 – 7009708<br />info@kiyoh<br />KVK nummer: 81275048<br />Openingstijden<br />Maandag t/m vrijdag<br />8.30 – 17.00 uur</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@
                 </div>
               </div>
             <div class="response-actions">
-                      <button class="toggle-response skeuo-glass"><span class="icon-reply"></span> lees verder <span class="fa fa-chevron-down"></span></button>
+                      <button class="toggle-response skeuo-glass">lees verder <span class="fa fa-chevron-down"></span></button>
                       <button class="share-button skeuo-glass"><span class="icon-share"></span> delen</button>
                     </div>
 </div>
@@ -1774,7 +1774,7 @@
                         </div>
                       </div>
                     <div class="response-actions">
-                      <button class="toggle-response skeuo-glass"><span class="icon-reply"></span> lees verder <span class="fa fa-chevron-down"></span></button>
+                      <button class="toggle-response skeuo-glass">lees verder <span class="fa fa-chevron-down"></span></button>
                       <button class="share-button skeuo-glass"><span class="icon-share"></span> delen</button>
                     </div>
 </div>


### PR DESCRIPTION
## Summary
- set `--font` variable to Gotham stack
- force body and paragraphs to use Gotham with 15px size and 1.6 line height
- remove custom font families from buttons, headings, and widgets
- normalize widget and signup page fonts

## Testing
- `grep -n "font-family" assets/public.css`

------
https://chatgpt.com/codex/tasks/task_e_68519e4509b08324a1cfd5a6c474607f