### PR TITLE
Add floating menu

### DIFF
--- a/assets/public.css
+++ b/assets/public.css
@@ -10879,3 +10879,66 @@ body.dark-mode .skeuo-glass {
 }
 .rating.as-stars{margin-left:.5em;}
 .name-city{display:block;margin-top:.2em;}
+
+/* Floating menu styled like iOS liquid glass */
+.menu-container {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 12px 20px;
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 24px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  width: fit-content;
+  max-width: 100%;
+  margin: auto;
+}
+
+.menu-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.3);
+  color: #000;
+  font-weight: 500;
+  font-size: 15px;
+  text-transform: none;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  transition: all 0.25s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(8px);
+}
+
+.menu-button:hover {
+  background: rgba(255, 255, 255, 0.45);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.menu-button.orange {
+  background: rgba(255, 102, 0, 0.2);
+  color: #ff6600;
+  border: 1px solid rgba(255, 102, 0, 0.3);
+}
+
+.menu-button.orange:hover {
+  background: rgba(255, 102, 0, 0.3);
+}
+
+.menu-icon {
+  margin-right: 8px;
+  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/index.html
+++ b/index.html
@@ -3097,6 +3097,20 @@
     </div>
   </div>
 </footer>
+<div class="menu-container">
+  <a href="https://www.kiyoh" class="menu-button">
+    <span class="menu-icon fa fa-home" aria-hidden="true"></span>
+    Home
+  </a>
+  <a href="#company-card" class="menu-button">
+    <span class="menu-icon fa fa-info-circle" aria-hidden="true"></span>
+    Over
+  </a>
+  <a href="https://www.kiyoh/reviews" class="menu-button orange">
+    <span class="menu-icon fa fa-star" aria-hidden="true"></span>
+    Reviews
+  </a>
+</div>
   <button class="scroll-top skeuo-glass" aria-label="Naar boven"><span class="fa fa-chevron-up" aria-hidden="true"></span></button>
   </body>
 


### PR DESCRIPTION
## Summary
- add floating bottom menu styled with iOS liquid glass look
- include new menu container markup in `index.html`
- style the menu with translucent blur in `assets/public.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853daaaa8ec8324b226ebf8e581e3ff