### PR TITLE
Fix menu order for small screens

### DIFF
--- a/assets/public.css
+++ b/assets/public.css
@@ -9607,11 +9607,13 @@ application-header .divider .wrapper .detail {
   gap: 1rem;
   padding: 0 1rem;
   box-sizing: border-box;
-  margin-top: -2rem;
+  margin-top: -3rem;
+  margin-bottom: 1rem;
 }
 
 body.dark-mode .summary-flex {
-  margin-top: -1rem;
+  margin-top: -2rem;
+  margin-bottom: 1rem;
 }
 
 
@@ -9696,6 +9698,8 @@ body.dark-mode .summary-flex {
   .summary-flex {
     flex-direction: column;
     width: 100%;
+    margin-top: -4rem;
+    margin-bottom: 1rem;
   }
 
   .summary-flex .review-summary,
@@ -10612,11 +10616,12 @@ header.public-header .header-rating {
 
 .menu-flex {
   max-width: 1200px;
-  margin: 0.5rem auto;
+  margin: 0 auto 1rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  flex-direction: row;
 }
 
 .menu-flex .public-filter {
@@ -10666,103 +10671,9 @@ review-filters .js-clear-button:hover {
   background: #c97700;
 }
 
-.menu-actions {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.menu-actions button {
-  width: 4rem;
-  height: 4rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border-radius: 50%;
-  font-size: 1.75rem;
-}
-.menu-actions .desc-btn {
-  width: 4rem;
-  height: 4rem;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  font-size: 1.75rem;
-  color: #000;
-  text-decoration: none;
-  gap: 0.25rem;
-}
-.menu-actions .desc-btn .fa {
-  font-size: 1.25rem;
-}
-.menu-actions .desc-btn .desc-text {
-  font-size: 0.9rem;
-  margin-left: 0.5rem;
-  color: #000;
-  font-weight: 600;
-}
-
-/* mobile menu button styling */
-.menu-actions .skeuo-glass {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  background: rgba(255, 255, 255, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.45);
-}
-.page-share .fa {
-  color: #fff;
-}
-.menu-actions .skeuo-glass:hover {
-  background: rgba(255, 255, 255, 0.35);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-}
-
-@media (max-width: 767px) {
-  .menu-flex { flex-direction: column; }
-  .menu-actions {
-    display: flex;
-    order: -1;
-    margin: 1rem 0;
-    width: 100%;
-    justify-content: space-around;
-    gap: 1rem;
-    padding: 0.5rem;
-    background: rgba(255, 255, 255, 0.3);
-    backdrop-filter: blur(15px);
-    -webkit-backdrop-filter: blur(15px);
-    border-radius: 30px;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
-  }
-  .menu-actions .fa {
-    color: #000;
-    font-weight: 900;
-  }
-  .menu-actions .page-share .fa {
-    color: #fff;
-  }
-  .menu-actions button {
-    width: 4rem;
-    height: 4rem;
-    font-size: 1.75rem;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-  }
-  .menu-actions .desc-btn{
-    display: flex;
-    font-size: 1rem;
-    height: auto;
-    width: auto;
-    padding: 0.5rem 1rem;
-    border-radius: 24px;
-  }
-}
 
 
-.menu-actions .page-share {
+.menu-container .page-share {
   background: #dd6825;
 }
 
@@ -10784,17 +10695,10 @@ review-filters .js-clear-button:hover {
 }
 
 .scroll-top {
-  position: fixed;
-  bottom: 1rem;
-  right: 1rem;
-  width: 3rem;
-  height: 3rem;
   display: none;
   align-items: center;
   justify-content: center;
-  border-radius: 50%;
   font-size: 1.8rem;
-  z-index: 1000;
 }
 .scroll-top .fa {
   color: #333;
@@ -10804,6 +10708,22 @@ review-filters .js-clear-button:hover {
 }
 @media (min-width: 768px) {
   .scroll-top { display: none !important; }
+  .menu-flex {
+    flex-direction: row;
+  }
+  .menu-flex .menu-container {
+    flex: 0 0 35%;
+    max-width: 35%;
+  }
+  .menu-container {
+    position: static;
+    margin: 0;
+    transform: none;
+    max-width: none;
+    bottom: auto;
+    left: auto;
+    right: auto;
+  }
 }
 
 @media (max-width: 767px) {
@@ -10813,6 +10733,17 @@ review-filters .js-clear-button:hover {
   .menu-flex .public-filter {
     flex-basis: 100%;
     max-width: 100%;
+  }
+  .menu-flex {
+    flex-direction: column;
+  }
+  .menu-flex .menu-container {
+    flex-basis: auto;
+    max-width: calc(100% - 2rem);
+  }
+  .menu-container {
+    width: fit-content;
+    max-width: calc(100% - 2rem);
   }
 }
 
@@ -10879,3 +10810,100 @@ body.dark-mode .skeuo-glass {
 }
 .rating.as-stars{margin-left:.5em;}
 .name-city{display:block;margin-top:.2em;}
+
+/* Floating menu styled like iOS liquid glass */
+.menu-container {
+  position: fixed;
+  bottom: 1rem;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 12px 20px;
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 24px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  width: fit-content;
+  max-width: calc(100% - 2rem);
+  margin: auto;
+  z-index: 1000;
+  transition: transform 0.35s ease, opacity 0.35s ease;
+  overflow: hidden;
+}
+
+.menu-container.menu-minimized {
+  transform: none;
+  padding: 2px 16px;
+  min-height: 8px;
+  gap: 0;
+  opacity: 0.85;
+  cursor: pointer;
+  width: calc(100% - 2rem);
+  margin: auto;
+}
+
+.menu-container.menu-minimized .menu-button {
+  display: none;
+}
+
+
+.menu-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.25);
+  color: #000;
+  font-weight: 500;
+  font-size: 15px;
+  text-transform: none;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  transition: all 0.25s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(8px);
+  cursor: pointer;
+}
+
+.menu-button:hover {
+  background: rgba(255, 255, 255, 0.45);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.menu-button.orange {
+  background: rgba(255, 102, 0, 0.2);
+  color: #ff6600;
+  border: 1px solid rgba(255, 102, 0, 0.3);
+}
+
+.menu-button.orange:hover {
+  background: rgba(255, 102, 0, 0.3);
+}
+
+.menu-icon {
+  margin-right: 6px;
+  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+}
+
+.desc-text {
+  display: block;
+  line-height: 1.2;
+  color: #000;
+  white-space: nowrap;
+}
+
+.menu-container .desc-btn {
+  flex: 1;
+  text-align: center;
+  color: #000;
+}
+

--- a/assets/review-interactions.js
+++ b/assets/review-interactions.js
@@ -152,5 +152,38 @@ document.addEventListener('DOMContentLoaded', function () {
       window.scrollTo({top:0, behavior:'smooth'});
     });
   }
+
+  var menuBar = document.querySelector('.menu-container');
+  if (menuBar) {
+    var lastY = window.scrollY;
+    var mq = window.matchMedia('(max-width: 767px)');
+
+    function handleMenu() {
+      if (!mq.matches) return;
+      var y = window.scrollY;
+      if (y > lastY + 5) {
+        menuBar.classList.add('menu-minimized');
+      } else if (y < lastY - 5) {
+        menuBar.classList.remove('menu-minimized');
+      }
+      lastY = y;
+    }
+
+    function toggleMenu() {
+      if (mq.matches) menuBar.classList.toggle('menu-minimized');
+    }
+
+    function updateState() {
+      if (!mq.matches) {
+        menuBar.classList.remove('menu-minimized');
+      }
+    }
+
+    mq.addEventListener('change', updateState);
+    window.addEventListener('scroll', function () {
+      window.requestAnimationFrame(handleMenu);
+    });
+    menuBar.addEventListener('click', toggleMenu);
+  }
 });
 

--- a/index.html
+++ b/index.html
@@ -306,7 +306,7 @@
       </div>
       <div class="company-summary frosted-card">
         <div>
-          <div class="map-square">
+          <div id="map" class="map-square">
             <iframe
               class="openstreetmap"
               src="https://www.openstreetmap.org/export/embed.html?bbox=5.1105,51.5535,5.1205,51.5635&layer=mapnik&marker=51.5585,5.1155"
@@ -342,8 +342,23 @@
         </div>
     </div>
   </div>
-  <div class="menu-flex">
-    <div class="filters public-filter js-public-filters component">
+    <div class="menu-flex">
+      <div class="menu-actions menu-container">
+        <button type="button" class="desc-btn menu-button" data-target="#company-card" aria-label="Bedrijfsoverzicht">
+          <span class="menu-icon fa fa-book" aria-hidden="true"></span>
+          <span class="desc-text">bedrijfsoverzicht</span>
+        </button>
+        <button class="page-share menu-button" aria-label="Deel reviewpagina">
+          <span class="menu-icon fa fa-share-alt" aria-hidden="true"></span>
+        </button>
+        <button class="access-btn menu-button" aria-label="Toegankelijkheid">
+          <span class="menu-icon fa fa-eye" aria-hidden="true"></span>
+        </button>
+        <button class="scroll-top menu-button" aria-label="Naar boven">
+          <span class="fa fa-chevron-up" aria-hidden="true"></span>
+        </button>
+      </div>
+      <div class="filters public-filter js-public-filters component">
       <div class="filters-block">
       <h2><b>Filters</b></h2>
       <ul>
@@ -410,11 +425,6 @@
         </li>
       </ul>
       </div>
-    </div>
-    <div class="menu-actions">
-      <button type="button" class="desc-btn skeuo-glass" data-target="#company-card" aria-label="Bedrijfsomschrijving"><span class="fa fa-book" aria-hidden="true"></span> <span class="desc-text">bedrijfsomschrijving</span></button>
-      <button class="page-share skeuo-glass" aria-label="Deel reviewpagina"><span class="fa fa-share-alt" aria-hidden="true"></span></button>
-      <button class="access-btn skeuo-glass" aria-label="Toegankelijkheid"><span class="fa fa-eye" aria-hidden="true"></span></button>
     </div>
   </div>
   <div class="scroll-flex">
@@ -499,7 +509,7 @@
         </div>
       </div>
     </div>
-    <div class="reviewlist">
+    <div id="reviews" class="reviewlist">
         <div class="reviews">
             <div bis_skin_checked="1" class="review frosted-card">
               <div bis_skin_checked="1" class="review-content">
@@ -3097,7 +3107,6 @@
     </div>
   </div>
 </footer>
-  <button class="scroll-top skeuo-glass" aria-label="Naar boven"><span class="fa fa-chevron-up" aria-hidden="true"></span></button>
   </body>
 
 </html>


### PR DESCRIPTION
## Summary
- set `.menu-flex` to display as a column on small screens
- ensure desktop layout stays horizontal
- space the menu from filters on mobile
- update floating menu text and spacing
- make floating menu use `.menu-container` style and position fixed
- hide menu while scrolling down and reduce gap above filters
- tweak menu so it minimizes into a thin bar
- keep the menu static beside the filters on desktop
- adjust menu width on mobile and hide buttons when minimized
- show pointer cursor on menu buttons
- reduce menu drop shadow and tweak minimized state width and padding

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853daaaa8ec8324b226ebf8e581e3ff